### PR TITLE
Fix reverse url build for non-integer object id's

### DIFF
--- a/admin_object_actions/admin.py
+++ b/admin_object_actions/admin.py
@@ -159,7 +159,7 @@ class ModelAdminObjectActionsMixin(object):
             wrapped_view = functools.update_wrapper(wrapped_view, view)
             object_action_urls.append(
                 re_path(
-                    r'^(?P<object_id>\d+)/{}/$'.format(action),
+                    r'^(?P<object_id>\S+)/{}/$'.format(action),
                     self.admin_site.admin_view(wrapped_view),
                     name=self.get_object_action_view_name(action),
                 )


### PR DESCRIPTION
Fix for:

```
django.urls.exceptions.NoReverseMatch: Reverse for 'api_document_assign' with arguments '(UUID('119e9c6b-51fb-4f28-8268-ad3d7f57bc69'),)' not found. 1 pattern(s) tried: ['admin/api/document/(?P<object_id>\\d+)/assign/$']
```

Alternative would be to use path instead of re_path with `path('<path:object_id>/{}/'.format(...)`