### PR TITLE
feat: add automatically display_object_actions_XXX fields

### DIFF
--- a/admin_object_actions/admin.py
+++ b/admin_object_actions/admin.py
@@ -327,3 +327,32 @@ class ModelAdminObjectActionsMixin(object):
             'admin/{}/object_action_form.html'.format(opts.app_label),
             'admin/object_action_form.html',
         ], context)
+
+    def has_display_object_actions_list(self):
+        return next((True for oa in self.get_object_actions() if not oa.get('detail_only')), False)
+
+    def has_display_object_actions_detail(self):
+        return next((True for oa in self.get_object_actions() if not oa.get('list_only')), False)
+
+    def get_list_display(self, request):
+        list_display = super().get_list_display(request)
+        if self.has_display_object_actions_list():
+            list_display = list(list_display) + ['display_object_actions_list']
+        return list_display
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = super().get_readonly_fields(request, obj)
+        if self.has_display_object_actions_detail():
+            readonly_fields = list(readonly_fields) + ['display_object_actions_detail']
+        return readonly_fields
+
+    def get_fieldsets(self, request, obj=None):
+        if self.has_display_object_actions_detail():
+            fields = [f for f in self.get_fields(request, obj) if f != 'display_object_actions_detail']
+            fieldsets = self.fieldsets if self.fieldsets else [(None, {'fields': fields})]
+            return list(fieldsets) + [
+                (self.display_object_actions_detail.short_description, {
+                    'fields': ('display_object_actions_detail', )
+                }),
+            ]
+        return super().get_fieldsets(request, obj)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ It is tested against:
  * Django 3.1 (Python 3.6, 3.7, 3.8 and 3.9)
  * Django 3.2 pre-release (Python 3.6, 3.7, 3.8 and 3.9)
  * Django main/4.0 (Python 3.8 and 3.9)
- 
+
 Installation
 ------------
 
@@ -49,36 +49,17 @@ Usage
 -----
 
 Ensure your ``ModelAdmin`` class inherits from the
-``ModelAdminObjectActionsMixin``. It should also include ``display_object_actions_list``
-in the ``list_display`` attribute and ``display_object_actions_detail`` in the
-``fields`` and ``readonly_fields`` attributes to ensure the object action buttons
-show up in the change list and change views, respectively::
+``ModelAdminObjectActionsMixin``.::
 
     # myapp/admin.py
     from django.contrib import admin
     from admin_object_actions.admin import ModelAdminObjectActionsMixin
     from .models import MyModel
-    
+
     @admin.register(MyModel)
     class MyModelAdmin(ModelAdminObjectActionsMixin, admin.ModelAdmin):
+        ...  # That's it
 
-        list_display = (
-            ...,  # your existing list display fields
-            'display_object_actions_list',
-        )
-
-        fields = (
-            ...,  # your existing detail display fields
-            'display_object_actions_detail',
-        )
-        
-        readonly_fields = (
-            ...,  # your existing read-only fields
-            'display_object_actions_detail',
-        )
-
-If using ``fieldsets`` instead of ``fields``, add ``display_object_actions_detail``
-to the desired fieldset as you would with any other field.
 
 Create custom subclasses of ``AdminObjectActionForm`` for actions requiring
 additional input or confirmation and implement the ``do_object_action`` method::
@@ -89,7 +70,7 @@ additional input or confirmation and implement the ``do_object_action`` method::
     from .models import MyModel
 
     class MyActionForm(AdminObjectActionForm):
-    
+
         confirm = forms.BooleanField()
 
         class Meta:
@@ -165,7 +146,7 @@ may define additional fields customize the action's behavior:
     List of readonly fields to display in the custom admin form.
 
   ``fields``
-    List of fields to display in the custom action form. 
+    List of fields to display in the custom action form.
 
   ``fieldsets``
     Custom fieldsets to display for the object action form. Defaults to a single
@@ -175,7 +156,7 @@ may define additional fields customize the action's behavior:
     Custom permission required to display or execute this object action. Default
     is ``change``. If defined, a ``has_<permission>_permission`` method on the
     ``ModelAdmin`` class will be called to check whether the action is allowed.
-    
+
   ``form_template``
     Custom form template used to render the object action form. Default is
     ``admin/object_action_form.html``.

--- a/test_project/test_app/admin.py
+++ b/test_project/test_app/admin.py
@@ -34,18 +34,15 @@ class TestModelAdmin(ModelAdminObjectActionsMixin, admin.ModelAdmin):
         'name',
         'enabled',
         'refreshed',
-        'display_object_actions_list',
     )
     fields = (
         'name',
         'enabled',
         'refreshed',
-        'display_object_actions_detail',
     )
     readonly_fields = (
         'enabled',
         'refreshed',
-        'display_object_actions_detail',
     )
     object_actions = [
         {


### PR DESCRIPTION
Instead of adding `display_object_actions_list` and `display_object_actions_detail` manually in each `ModelAdmin` class, simply override the django methods to add them when required.